### PR TITLE
Add introspection and metaprogramming features to Functions filter

### DIFF
--- a/lib/ruby2js.rb
+++ b/lib/ruby2js.rb
@@ -139,6 +139,7 @@ module Ruby2JS
       def on_class_extend(node); on_send(node); end
       def on_class_module(node); on_send(node); end
       def on_constructor(node); on_def(node); end
+      def on_deff(node); on_def(node); end
       def on_defm(node); on_defs(node); end
       def on_defp(node); on_defs(node); end
       def on_for_of(node); on_for(node); end

--- a/lib/ruby2js/converter/def.rb
+++ b/lib/ruby2js/converter/def.rb
@@ -6,7 +6,7 @@ module Ruby2JS
     #     (arg :x)
     #   (...)
 
-    handle :def, :defm, :async do |name, args, body=nil|
+    handle :def, :defm, :async, :deff do |name, args, body=nil|
       body ||= s(:begin)
 
       add_implicit_block = false
@@ -106,7 +106,7 @@ module Ruby2JS
       # es2015 fat arrow support
       if \
         not name and es2015 and @state != :method and @ast.type != :defm and 
-        not @prop
+        @ast.type != :deff and not @prop
       then
         expr = body
         expr = expr.children.first while expr.type == :autoreturn

--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -750,6 +750,7 @@ module Ruby2JS
 
         elsif method == :define_method and call.children.length == 3
           process node.updated(:send, [s(:attr, call.children[0], :prototype), :"#{call.children[2].children[0]}=", s(:deff, nil, *node.children[1..-1])])
+
         else
           super
         end

--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -551,6 +551,17 @@ module Ruby2JS
             s(:args, s(:arg, :a), s(:arg, :b)),
             s(:send, s(:lvar, :a), :+, s(:lvar, :b))), s(:int, 0))
 
+        elsif method == :method_defined? and args.length >= 1
+          if args[1] and args[1].type == :false
+            process S(:send, target, :hasOwnProperty, args[0])
+          else
+            process S(:in?, args[0], target)
+          end
+
+        elsif method == :alias_method and args.length == 2
+          process S(:send, s(:attr, target, :prototype), :"#{args[0].children[0]}=",
+            s(:attr, s(:attr, target, :prototype), args[1].children[0]))
+
         else
           super
         end
@@ -737,6 +748,8 @@ module Ruby2JS
             s(:return, s(:lvar, node.children[1].children[0].children[0])))),
             :[], call.children[0]])
 
+        elsif method == :define_method and call.children.length == 3
+          process node.updated(:send, [s(:attr, call.children[0], :prototype), :"#{call.children[2].children[0]}=", s(:deff, nil, *node.children[1..-1])])
         else
           super
         end

--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -782,7 +782,7 @@ module Ruby2JS
               s(:lvar, :message)), :stack))))
           end
 
-          body = [s(:begin, body)] if body.length > 1
+          body = [s(:begin, *body)] if body.length > 1
           S(:class, name, s(:const, nil, :Error), *body)
         else
           body = [s(:begin, *body)] if body.length > 1

--- a/lib/ruby2js/filter/return.rb
+++ b/lib/ruby2js/filter/return.rb
@@ -20,7 +20,7 @@ module Ruby2JS
 
       def on_def(node)
         node = super
-        return node unless node.type == :def
+        return node unless node.type == :def or node.type == :deff
         return node if [:constructor, :initialize].include?(node.children.first)
 
         children = node.children[1..-1]
@@ -29,6 +29,10 @@ module Ruby2JS
 
         node.updated nil, [node.children[0], children.first,
           s(:autoreturn, *children[1..-1])]
+      end
+
+      def on_deff(node)
+        on_def(node)
       end
     end
 

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -8,6 +8,10 @@ describe Ruby2JS::Filter::Functions do
     _(Ruby2JS.convert(string, filters: [Ruby2JS::Filter::Functions]).to_s)
   end
 
+  def to_js_2020(string)
+    _(Ruby2JS.convert(string, eslevel: 2020, filters: [Ruby2JS::Filter::Functions]).to_s)
+  end
+
   describe 'conversions' do
     it "should handle to_s" do
       to_js( 'a.to_s' ).must_equal 'a.toString()'
@@ -541,6 +545,22 @@ describe Ruby2JS::Filter::Functions do
 
     it "should handle floor" do
       to_js( 'a.floor' ).must_equal 'Math.floor(a)'
+    end
+  end
+
+  describe "introspection and metaprogramming" do
+    it "should handle method_defined?" do
+      to_js( 'a.method_defined? :meth').must_equal '"meth" in a'
+      to_js( 'a.method_defined? :meth, true').must_equal '"meth" in a'
+      to_js( 'a.method_defined? :meth, false').must_equal 'a.hasOwnProperty("meth")'
+    end
+
+    it "should handle alias_method" do
+      to_js( 'Klass.alias_method :newname, :oldname').must_equal 'Klass.prototype.newname = Klass.prototype.oldname'
+    end
+
+    it "should handle define_method" do
+      to_js_2020( 'Klass.define_method(:newname) {|x| return x * 5 }').must_equal 'Klass.prototype.newname = function(x) {return x * 5}'
     end
   end
 

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -553,14 +553,19 @@ describe Ruby2JS::Filter::Functions do
       to_js( 'a.method_defined? :meth').must_equal '"meth" in a'
       to_js( 'a.method_defined? :meth, true').must_equal '"meth" in a'
       to_js( 'a.method_defined? :meth, false').must_equal 'a.hasOwnProperty("meth")'
+      to_js( 'result = a.method_defined? :meth, expr').
+        must_equal 'var result = expr ? "meth" in a : a.hasOwnProperty("meth")'
     end
 
     it "should handle alias_method" do
       to_js( 'Klass.alias_method :newname, :oldname').must_equal 'Klass.prototype.newname = Klass.prototype.oldname'
+      to_js_2020( 'class C; alias_method :c, :d; end').
+        must_equal 'class C {}; C.prototype.c = C.prototype.d'
     end
 
     it "should handle define_method" do
       to_js_2020( 'Klass.define_method(:newname) {|x| return x * 5 }').must_equal 'Klass.prototype.newname = function(x) {return x * 5}'
+      to_js_2020( 'Klass.define_method(newname) {|x| return x * 5 }').must_equal 'Klass.prototype[newname] = function(x) {return x * 5}'
     end
   end
 


### PR DESCRIPTION
Resolves #89 

I ended up adding a couple more methods besides `method_defined?`, but in implementing `define_method`, I ran into an issue. Adding new methods to a JS class via `Klass.prototype.methodname =` requires using regular `function` and not fat arrow functions. But in es2015+, anonymous blocks (via `def`) always convert to arrow functions.

So I brute-forced a solution by adding a new `deff` AST type and using the right logic to ensure it's always converted to `function`. It works, but it's not too elegant. If you have a better idea, I'm all ears!