### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+cache: bundler
+
 #before_install:
 # # Workaround for https://github.com/travis-ci/travis-ci/issues/8969
 # - gem update --system


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.