### PR TITLE
Pragmas

### DIFF
--- a/lib/ruby2js.rb
+++ b/lib/ruby2js.rb
@@ -224,7 +224,7 @@ module Ruby2JS
       file,line = source.source_location
       source = IO.read(file)
       ast, comments = parse(source)
-      comments = Parser::Source::Comment.associate(ast, comments) if ast
+      comments = Parser::Source::Comment.associate_by_identity(ast, comments) if ast
       ast = find_block( ast, line )
       options[:file] ||= file
     elsif Parser::AST::Node === source
@@ -232,7 +232,7 @@ module Ruby2JS
       source = ast.loc.expression.source_buffer.source
     else
       ast, comments = parse( source, options[:file] )
-      comments = ast ? Parser::Source::Comment.associate(ast, comments) : {}
+      comments = ast ? Parser::Source::Comment.associate_by_identity(ast, comments) : {}
     end
 
     # check if magic comment is present

--- a/lib/ruby2js/converter/logical.rb
+++ b/lib/ruby2js/converter/logical.rb
@@ -15,6 +15,12 @@ module Ruby2JS
     handle :and, :or do |left, right|
       type = @ast.type
 
+      default_or = ' || '
+
+      if es2020
+        # Override '||' and use '??'
+        default_or = ' ?? ' if @pragma == '??'
+      end
 
       if es2020 and type == :and
         node = rewrite(left, right)
@@ -36,7 +42,7 @@ module Ruby2JS
       rgroup = true if right.type == :begin
 
       put '(' if lgroup; parse left; put ')' if lgroup
-      put (type==:and ? ' && ' : ((@or == :nullish and es2020) ? ' ?? ' : ' || '))
+      put (type==:and ? ' && ' : ((@or == :nullish and es2020) ? ' ?? ' : default_or))
       put '(' if rgroup; parse right; put ')' if rgroup
     end
 

--- a/lib/ruby2js/converter/opasgn.rb
+++ b/lib/ruby2js/converter/opasgn.rb
@@ -54,8 +54,15 @@ module Ruby2JS
       vtype = :ivar if asgn.type == :ivasgn
       vtype = :cvar if asgn.type == :cvasgn
       
-      if es2021
-        op = type == :and ? '&&' : (@or == :nullish ? '??' : '||')
+      if es2020
+        default_or = '||'
+
+        if @pragma == '??'
+          # Override '||' and use '??'
+          default_or = '??'
+        end
+
+        op = type == :and ? '&&' : (@or == :nullish ? '??' : default_or)
         parse s(:op_asgn, asgn, op, value);
       elsif vtype
         parse s(asgn.type, asgn.children.first, s(type, 

--- a/lib/ruby2js/converter/super.rb
+++ b/lib/ruby2js/converter/super.rb
@@ -24,23 +24,29 @@ module Ruby2JS
       end
 
       if es2015
+        add_args = true
+
         if @class_method
           parse @class_parent
           put '.'
           put method.children[0]
+          add_args = method.is_method?
         elsif method.children[0] == :constructor
           put 'super'
         else
           put 'super.'
           put method.children[0]
+          add_args = method.is_method?
         end
 
-        put '('
-        cleaned_args = args.map do |arg| # FIX: #212
-          arg.type == :optarg ? s(:arg, arg.children[0]) : arg
+        if add_args
+          put '('
+          cleaned_args = args.map do |arg| # FIX: #212
+            arg.type == :optarg ? s(:arg, arg.children[0]) : arg
+          end
+          parse s(:args, *cleaned_args)
+          put ')'
         end
-        parse s(:args, *cleaned_args)
-        put ')'
       else
         parse @class_parent
 


### PR DESCRIPTION
Add support for Pragmas. A pragma can be added by the addition of a comment at the end of a line. The comment has the format "# Pragma: xxxxx" where xxxxx is the name of a specific supported pragma. Each pragma, when enabled changes the way in which the line is translated in some way.

Initial support is included for a nullish coalescing pragma which changes all '||' operators to '??' within a line. It is enabled with a '??' pragma.

For example:

a ||= b # Pragma: ??

This results in the translation:

a ??= b;