### PR TITLE
Add Prism parser support with backwards compatibility

### DIFF
--- a/lib/ruby2js/converter/class.rb
+++ b/lib/ruby2js/converter/class.rb
@@ -330,7 +330,10 @@ module Ruby2JS
           end
         end
 
-        @comments[constructor] = @comments[init] unless @comments[init].empty?
+        unless @comments[init].empty?
+          @comments[constructor] = @comments[init]
+          @comments[init] = []  # prevent duplicate output
+        end
         body.unshift constructor
       end
 

--- a/lib/ruby2js/filter/node.rb
+++ b/lib/ruby2js/filter/node.rb
@@ -370,6 +370,19 @@ module Ruby2JS
       def on___FILE__(node)
         s(:attr, nil, :__filename)
       end
+
+      # Handle __FILE__ from Prism::Translation::Parser which produces :str nodes
+      def on_str(node)
+        # Prism converts __FILE__ to s(:str, filename) where filename matches buffer name
+        if node.loc&.expression
+          source = node.loc.expression.source
+          buffer_name = node.loc.expression.source_buffer.name
+          if source == '__FILE__' && node.children.first == buffer_name
+            return s(:attr, nil, :__filename)
+          end
+        end
+        super
+      end
     end
 
     DEFAULTS.push Node

--- a/lib/ruby2js/filter/require.rb
+++ b/lib/ruby2js/filter/require.rb
@@ -63,8 +63,9 @@ module Ruby2JS
 
               @options[:file2] = filename
               ast, comments = Ruby2JS.parse(File.read(filename), filename)
-              @comments.merge! Parser::Source::Comment.associate(ast, comments)
-              @comments[node] += @comments[ast]
+              # comments is already a hash with associated comments, merge it directly
+              @comments.merge!(comments) { |key, old, new| old + new }
+              @comments[node] += @comments[ast] if @comments[ast]
             end
 
             children = ast.type == :begin ? ast.children : [ast]

--- a/lib/ruby2js/filter/vue.rb
+++ b/lib/ruby2js/filter/vue.rb
@@ -437,6 +437,9 @@ module Ruby2JS
           }).compact, *@vue_reactive)
         end
 
+        # Copy class-level comments to the generated definition
+        @comments[defn] = @comments[node] unless @comments[node].empty?
+
         vue_collapse_pushes(defn)
       end
 


### PR DESCRIPTION
## Summary

- Add support for Prism (Ruby 3.3+) as an alternative parser while maintaining full backwards compatibility with older Ruby versions using the whitequark parser gem
- Auto-detects Prism if available, falls back to parser gem; can override with `RUBY2JS_PARSER=prism` or `RUBY2JS_PARSER=parser` environment variable
- Uses `Prism::Translation::Parser` which produces `Parser::AST::Node` objects, so all existing filters and converters work unchanged

## Edge cases fixed for Prism compatibility

- `__FILE__` handling (Prism produces `:str` instead of `:__FILE__`)
- Comment association with synthetic AST nodes
- Consecutive tilde handling in jQuery filter
- Class-level comments in Vue filter

## Test plan

- [x] All 1302 tests pass with both parsers
- [ ] Verify Prism detection works on Ruby 3.3+
- [ ] Verify fallback to parser gem on older Ruby versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)