### PR TITLE
Update Opal to 1.8 and modernize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [3.1, 3.2, 3.3]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      
+    - uses: actions/checkout@v4
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    
+
     - name: Run tests
       run: bundle exec rake test
 
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      
+    - uses: actions/checkout@v4
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
         bundler-cache: true
 
     - name: Set up Node

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ group :development, :test do
   gem 'rake'
   gem 'execjs'
   gem 'nokogiri'
-  gem 'opal', '1.1.1'
+  gem 'opal', '~> 1.8'
+  gem 'base64' # Required for Opal on Ruby 3.4+
 end
 
 group :test do

--- a/demo/patch.opal
+++ b/demo/patch.opal
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 # silence YAML warning
 `Opal.modules["yaml"] = function() {}`
 
@@ -18,6 +20,12 @@ class Parser::Lexer
       @source_pts = source.unpack('U*')
     else
       @source_pts = nil
+    end
+
+    # Since parser v3.2.1 Parser::Lexer has @strings
+    if @strings
+      @strings.source_buffer = @source_buffer
+      @strings.source_pts = @source_pts
     end
   end
 end
@@ -277,6 +285,12 @@ module Parser
       else
         diagnostic :error, :lvar_name, { name: name }, loc
       end
+    end
+
+    # string_value raises on invalid UTF-8 strings, like "\x80",
+    # otherwise it's the same as value.
+    def string_value(token)
+      value(token)
     end
   end
 end

--- a/demo/ruby2js.opal
+++ b/demo/ruby2js.opal
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 require 'native'
 require 'ruby2js/demo'
 require 'patch.opal'
@@ -116,8 +118,15 @@ end
 }`
 
 # Define a getter for sourcemap
+# In Opal 1.8+, Ruby Hashes are JavaScript Maps, so convert to plain object
 `Object.defineProperty(Opal.Ruby2JS.Serializer.$$prototype, "sourcemap",
-  {get() { return this.$sourcemap().$$smap }})`
+  {get() {
+    const map = this.$sourcemap();
+    if (map instanceof Map) {
+      return Object.fromEntries(map);
+    }
+    return map.$$smap || map;
+  }})`
 
 # advertise that the function is available
 if `typeof module !== 'undefined' && module.parent`


### PR DESCRIPTION
## Summary

- Update Opal from 1.1.1 to ~> 1.8 for Ruby 3.3+ compatibility
- Add `base64` gem required for Ruby 3.4+ (no longer in stdlib)
- Update CI Ruby matrix from `[2.7, 3.0, 3.1]` to `[3.1, 3.2, 3.3]`
- Update `actions/checkout` from v2 to v4
- Add parser patches for Opal 1.8 compatibility:
  - Handle `@strings` in `Parser::Lexer#source_buffer=` (required since parser v3.2.1)
  - Add `string_value` method to `Parser::Builders::Default`
- Fix sourcemap getter to handle Opal 1.8's JavaScript Map output (convert to plain object)
- Add `# backtick_javascript: true` magic comments for Opal 2.0 compatibility

## Background

The package-test CI job was failing with `undefined method 'source' for nil` because Opal 1.1.1 is incompatible with Ruby 3.3+. Updating to Opal 1.8 required corresponding patches to the parser integration code.

## Test plan

- [x] All 1302 gem tests pass (`bundle exec rake test`)
- [x] All 9 package tests pass (`bundle exec rake packages:test`)
- [x] String literal parsing works in Opal-compiled code
- [x] Sourcemaps work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)