### PR TITLE
Add idiomatic Ruby patterns for nullish operators

### DIFF
--- a/docs/src/_docs/eslevels.md
+++ b/docs/src/_docs/eslevels.md
@@ -126,6 +126,7 @@ conversions are made:
 {:.functions-list}
 * `a&.b` {{ caret }} `a?.b`
 * `.scan` {{ caret }} `Array.from(str.matchAll(/.../g), s => s.slice(1))`
+* `a.nil? ? b : a` {{ caret }} `a ?? b`
 
 ## ES2021 support
 
@@ -135,8 +136,14 @@ conversions are made:
 {:.functions-list}
 * `x ||= 1` {{ caret }} `x ||= 1`
 * `x &&= 1` {{ caret }} `x &&= 1`
+* `x = y if x.nil?` {{ caret }} `x ??= y`
 * `1000000.000001` {{ caret }} `1_000_000.000_001`
 * `'.gsub' {{ caret }} `.replaceAll`
+
+The `x = y if x.nil?` pattern provides an idiomatic Ruby way to express
+nullish assignment. This is useful when you want nullish semantics (only
+assign if `nil`) rather than the falsy semantics of `||=` (which also
+triggers on `false`).
 
 ## ES2022 support
 

--- a/spec/es2020_spec.rb
+++ b/spec/es2020_spec.rb
@@ -61,6 +61,12 @@ describe "ES2020 support" do
       # Non-boolean contexts should use ??
       to_js_nullish( 'x = a || b' ).must_equal 'let x = a ?? b'
     end
+
+    it "should convert 'a.nil? ? b : a' to nullish coalescing" do
+      to_js( 'a.nil? ? b : a' ).must_equal 'a ?? b'
+      to_js( '@a.nil? ? b : @a' ).must_equal 'this._a ?? b'
+      to_js( 'foo.bar.nil? ? default_val : foo.bar' ).must_equal 'foo.bar ?? default_val'
+    end
   end
 
   describe :OptionalChaining do

--- a/spec/es2021_spec.rb
+++ b/spec/es2021_spec.rb
@@ -49,5 +49,13 @@ describe "ES2021 support" do
     to_js_fn( 'x.gsub("a", "b")' ).must_equal 'x.replaceAll("a", "b")'
     to_js_fn( 'x.gsub(/a/, "b")' ).must_equal 'x.replaceAll(/a/g, "b")'
   end
-    
+
+  it "should convert 'a = b if a.nil?' to nullish assignment" do
+    to_js( 'a = b if a.nil?' ).must_equal 'a ??= b'
+    to_js( '@a = b if @a.nil?' ).must_equal 'this._a ??= b'
+    to_js( '@@a = b if @@a.nil?' ).must_equal 'this.constructor._a ??= b'
+    to_js( 'self.foo = b if self.foo.nil?' ).must_equal 'this.foo ??= b'
+    to_js( 'a[i] = b if a[i].nil?' ).must_equal 'a[i] ??= b'
+  end
+
 end


### PR DESCRIPTION
## Summary

This PR adds support for recognizing Ruby idioms that express nullish semantics and converting them to JavaScript's nullish operators (`??` and `??=`).

### ES2021 - Nullish Assignment (`??=`)

| Ruby | JavaScript |
|------|------------|
| `a = b if a.nil?` | `a ??= b` |
| `@a = b if @a.nil?` | `this._a ??= b` |
| `@@a = b if @@a.nil?` | `this.constructor._a ??= b` |
| `self.foo = b if self.foo.nil?` | `this.foo ??= b` |
| `a[i] = b if a[i].nil?` | `a[i] ??= b` |

### ES2020 - Nullish Coalescing (`??`)

| Ruby | JavaScript |
|------|------------|
| `a.nil? ? b : a` | `a ?? b` |

## Motivation

This is offered as an alternative approach to PR #218's pragma-based solution for nullish operators.

The key insight is that Ruby already has idiomatic ways to express "assign only if nil" (`x = y if x.nil?`) and "use value or fallback if nil" (`x.nil? ? fallback : x`). These patterns map perfectly to JavaScript's nullish operators.

### Advantages over pragma approach:

1. **No new syntax** - uses existing Ruby patterns
2. **Self-documenting** - the Ruby code says exactly what it means
3. **Works in pure Ruby** - the code runs correctly in Ruby too
4. **Consistent** - similar to how `x&.foo` maps to `x?.foo`

### When to use:

Use these patterns when you want **nullish semantics** (only trigger on `nil`) rather than the **falsy semantics** of `||=` (which also triggers on `false`):

```ruby
# Want nullish: 0 and false are valid values
count = default_count if count.nil?   # => count ??= default_count
enabled = config.nil? ? true : config # => config ?? true

# Want falsy: false should also trigger fallback  
enabled ||= true
```

## Test Plan

- [x] Added tests for all nullish assignment patterns in `spec/es2021_spec.rb`
- [x] Added tests for nullish coalescing pattern in `spec/es2020_spec.rb`
- [x] All existing tests pass (1304 tests, 0 failures)
- [x] Updated documentation in `docs/src/_docs/eslevels.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)