### PR TITLE
Fix export const for modules with constants

### DIFF
--- a/lib/ruby2js/converter/import.rb
+++ b/lib/ruby2js/converter/import.rb
@@ -104,6 +104,19 @@ module Ruby2JS
         else
           put 'const '
         end
+      elsif node.respond_to?(:type) && node.type == :module
+        # Check if module will go through IIFE path (has non-def/module children)
+        body = node.children[1..-1]
+        while body.length == 1 and body.first.respond_to?(:type) and body.first.type == :begin
+          body = body.first.children
+        end
+        uses_iife = body.length > 0 && !body.all? { |child|
+          child.respond_to?(:type) && (
+            %i[def module].include?(child.type) ||
+            (es2015 && child.type == :class && child.children[1] == nil)
+          )
+        }
+        put 'const ' if uses_iife
       elsif node.respond_to?(:type) &&
         node.type == :array &&
         node.children[0].respond_to?(:type) &&

--- a/spec/esm_spec.rb
+++ b/spec/esm_spec.rb
@@ -125,6 +125,11 @@ describe Ruby2JS::Filter::ESM do
       to_js('Foo=1', autoexports: true).
         must_equal 'export const Foo = 1'
     end
+
+    it "should autoexport modules with constants" do
+      to_js('module Foo; BAR = 1; def baz; BAR; end; end', autoexports: true).
+        must_include 'export const Foo = '
+    end
   end
 
   describe "autoexports default option" do


### PR DESCRIPTION
## Summary

Fixes #228

When a module contains constants, the ESM autoexports filter was generating invalid JavaScript syntax:

```ruby
module Hello
  WORD = "world"
  def hi()
    puts WORD
  end
end
```

**Before (invalid):**
```js
export Hello = (() => {
  const WORD = "world";
  function hi() { return console.log(WORD) };
  return {WORD, hi}
})()
```

**After (valid):**
```js
export const Hello = (() => {
  const WORD = "world";
  function hi() { return console.log(WORD) };
  return {WORD, hi}
})()
```

## Root Cause

When a Ruby module contains constants (like `WORD = "world"`), the module converter takes a different code path (IIFE - Immediately Invoked Function Expression) than simple modules containing only methods. The export handler wasn't adding the required `const` keyword for this case.

## Changes

- Added logic in the export handler to detect modules that will use the IIFE path (modules containing non-def/module children like constants) and explicitly output `const` for those cases
- Added a test case for autoexporting modules with constants

## Test plan

- [x] All existing tests pass (1305 runs, 2490 assertions)
- [x] New test case for modules with constants passes
- [x] Verified fix with the exact example from issue #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)