### PR TITLE
Fix function conversion after conditional chaining operator

### DIFF
--- a/lib/ruby2js.rb
+++ b/lib/ruby2js.rb
@@ -198,12 +198,14 @@ module Ruby2JS
       def on_send(node)
         if node.children.length > 2 and node.children.last.type == :block_pass
           method = node.children.last.children.first.children.last
+          # preserve csend type for optional chaining
+          call_type = node.type == :csend ? :csend : :send
           if BINARY_OPERATORS.include? method
-            return on_block s(:block, s(:send, *node.children[0..-2]),
+            return on_block s(:block, s(call_type, *node.children[0..-2]),
               s(:args, s(:arg, :a), s(:arg, :b)), s(:return,
               process(s(:send, s(:lvar, :a), method, s(:lvar, :b)))))
           elsif node.children.last.children.first.type == :sym
-            return on_block s(:block, s(:send, *node.children[0..-2]),
+            return on_block s(:block, s(call_type, *node.children[0..-2]),
               s(:args, s(:arg, :item)), s(:return,
               process(s(:attr, s(:lvar, :item), method))))
           else
@@ -211,6 +213,10 @@ module Ruby2JS
           end
         end
         super
+      end
+
+      def on_csend(node)
+        on_send(node)
       end
     end
   end

--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -22,6 +22,17 @@ module Ruby2JS
         super
       end
 
+      def on_csend(node)
+        # process csend (safe navigation) nodes the same as send nodes
+        # so method names get converted (e.g., include? -> includes)
+        # then restore the csend type if needed
+        result = on_send(node)
+        if result&.type == :send and node.type == :csend
+          result = result.updated(:csend)
+        end
+        result
+      end
+
       def on_send(node)
         target, method, *args = node.children
         return super if excluded?(method) and method != :call

--- a/spec/es2020_spec.rb
+++ b/spec/es2020_spec.rb
@@ -95,5 +95,17 @@ describe "ES2020 support" do
       to_js('foo() if bar and bar != @bar').
         must_equal 'if (bar && bar != this._bar) foo()'
     end
+
+    unless (RUBY_VERSION.split('.').map(&:to_i) <=> [2, 3, 0]) == -1
+      it "should convert methods after optional chaining" do
+        to_js_fn('filter.subTypes&.include?(item.subType)').
+          must_equal 'filter.subTypes?.includes(item.subType)'
+      end
+
+      it "should convert proc symbols after optional chaining" do
+        to_js_fn('a&.map(&:to_i)').
+          must_equal 'a?.map(item => parseInt(item))'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes #225: Functions are not converted after conditional chaining
- Method names (e.g., `include?` → `includes`) now work with optional chaining (`&.`)
- Proc symbols (e.g., `&:to_i`) now preserve optional chaining

## Test plan
- [x] Added tests for method conversion after optional chaining
- [x] Added tests for proc symbol conversion after optional chaining
- [x] All existing tests pass (1306 runs, 2490 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)