### PR TITLE
Support multiple rescue clauses with different exception variables

### DIFF
--- a/spec/notimplemented_spec.rb
+++ b/spec/notimplemented_spec.rb
@@ -35,11 +35,6 @@ describe 'not implemented' do
     todo( 'class C; protected; end' )
   end
 
-  it "catching exceptions with different variables" do
-    todo("begin; a; rescue StandardException => se; b; " +
-      "rescue Exception => e; c; end")
-  end
-
   it "else clauses in begin...end" do
     todo("begin; a; rescue => e; b; else; c; end")
   end

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -1142,6 +1142,16 @@ describe Ruby2JS do
         must_equal 'try {var a} catch (e) {var b} finally {var c}'
     end
 
+    it "should handle multiple rescue clauses with different variables" do
+      to_js( 'begin; a; rescue FooError => foo; b(foo); rescue BarError => bar; c(bar); end' ).
+        must_equal 'try {var a} catch (foo) {if (foo instanceof FooError) {b(foo)} else if (foo instanceof BarError) {var bar = foo; c(bar)} else {throw foo}}'
+    end
+
+    it "should handle multiple rescue clauses with mixed variable usage" do
+      to_js( 'begin; a; rescue FooError => e; b(e); rescue BarError; c; end' ).
+        must_equal 'try {var a} catch (e) {if (e instanceof FooError) {b(e)} else if (e instanceof BarError) {var c} else {throw e}}'
+    end
+
     it "should handle implicit begin in methods" do
       to_js( 'def foo; x(); rescue => e; y(e); end' ).
         must_equal 'function foo() {try {x()} catch (e) {y(e)}}'


### PR DESCRIPTION
## Summary

- Removes the restriction requiring all rescue clauses to use the same variable
- Uses the first named variable as the catch variable
- Adds variable assignments at the start of rescue branches that use different variable names
- Fixes the "multiple recovers with different exception variables" error reported in #226

### Example

```ruby
begin
  risky_operation
rescue FooError => foo
  handle_foo(foo)
rescue BarError => bar
  handle_bar(bar)
end
```

Now correctly generates:

```javascript
try {
  risky_operation
} catch (foo) {
  if (foo instanceof FooError) {
    handle_foo(foo)
  } else if (foo instanceof BarError) {
    var bar = foo;
    handle_bar(bar)
  } else {
    throw foo
  }
}
```

## Test plan

- [x] Added tests for multiple rescue clauses with different variables
- [x] Added tests for mixed variable usage (some with, some without)
- [x] Removed the "not implemented" test for this feature
- [x] All existing tests pass

Fixes part of #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)