### PR TITLE
Fix is_a?, kind_of?, instance_of? with safe navigation operator

### DIFF
--- a/lib/ruby2js/converter/send.rb
+++ b/lib/ruby2js/converter/send.rb
@@ -372,6 +372,17 @@ module Ruby2JS
     end
 
     handle :csend do |receiver, method, *args|
+      # is_a?, kind_of?, instance_of? cannot use optional chaining because
+      # they need to be converted to instanceof/constructor checks
+      if [:is_a?, :kind_of?, :instance_of?].include?(method) and args.length == 1
+        # Convert to: receiver && (receiver instanceof/constructor check)
+        # Output directly to avoid rewrite() converting back to csend
+        parse receiver
+        put ' && '
+        parse @ast.updated(:send)
+        return
+      end
+
       if es2020
 
         # optional chaining

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -959,6 +959,12 @@ describe Ruby2JS do
       to_js( 'x unless a.kind_of? b' ).must_equal "if (!(a instanceof b)) var x"
       to_js( 'x unless a.instance_of? b' ).must_equal "if (!(a.constructor == b)) var x"
     end
+
+    it "should handle is_a?, kind_of?, instance_of? with safe navigation" do
+      to_js( 'a&.is_a? b' ).must_equal "a && (a instanceof b)"
+      to_js( 'a&.kind_of? b' ).must_equal "a && (a instanceof b)"
+      to_js( 'a&.instance_of? b' ).must_equal "a && (a.constructor == b)"
+    end
   end
 
   describe 'attribute access' do


### PR DESCRIPTION
## Summary

Fixes the issue where `is_a?`, `kind_of?`, and `instance_of?` methods were not being converted to their JavaScript equivalents when used with the safe navigation operator (`&.`) in ES2020+ mode.

### Before (with ES2020)

```ruby
event&.is_a?(Event)
```

Incorrectly generated:
```javascript
event?.is_a?(Event)  // Invalid JavaScript
```

### After

```ruby
event&.is_a?(Event)
```

Now correctly generates:
```javascript
event && (event instanceof Event)
```

## Technical Details

These methods cannot use optional chaining (`?.`) because they need to be converted to `instanceof` or `constructor` checks. The fix detects these methods in the `:csend` handler and outputs the `&&` pattern directly instead of attempting to use optional chaining.

## Test plan

- [x] Added tests for `is_a?`, `kind_of?`, `instance_of?` with safe navigation
- [x] Verified existing tests still pass
- [x] Tested with and without ES2020 option

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)