### PR TITLE
Fix crash on empty case/when blocks

### DIFF
--- a/lib/ruby2js/converter/case.rb
+++ b/lib/ruby2js/converter/case.rb
@@ -57,8 +57,8 @@ module Ruby2JS
           end
 
           if other or index < whens.length-1
-            put "#{@sep}" 
-            put "break#@sep" unless last.type == :return
+            put "#{@sep}"
+            put "break#@sep" unless last&.type == :return
           end
         end
 

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -474,6 +474,11 @@ describe Ruby2JS do
         must_equal 'var x = function() {switch (a) {case true: return b; default: return c}}()'
     end
 
+    it "should handle empty when blocks" do
+      to_js( 'case a; when 1; when 2; b; end' ).
+        must_equal 'switch (a) {case 1: ; break; case 2: var b}'
+    end
+
     it "should handle a for loop" do
       to_js( 'a = {}; b = {}; for i in a; b[i] = a[i]; end' ).
         must_equal 'var a = {}; var b = {}; for (var i in a) {b[i] = a[i]}'


### PR DESCRIPTION
## Summary

Fixes a crash that occurred when a `when` block was empty (e.g., containing only a comment).

### Before

```ruby
case type
  when 1
    # Do nothing
  when 2
    total += 1
end
```

Would crash with:
```
undefined method 'type' for nil (NoMethodError)
```

### After

Now correctly generates:
```javascript
switch (type) {
case 1:
  ;
  break;

case 2:
  total++
}
```

## Technical Details

The fix adds a safe navigation operator (`&.`) when checking if the last statement is a `return` on line 61 of `case.rb`. When the `when` block is empty, `last` is `nil`, and calling `.type` on it caused the crash.

## Test plan

- [x] Added test for empty when blocks
- [x] Verified fix works with empty when at beginning, middle, and end
- [x] Verified fix works with else clause present
- [x] All existing tests pass

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)