### PR TITLE
Fix missing commas in conditional chaining method arguments

### DIFF
--- a/lib/ruby2js/converter/send.rb
+++ b/lib/ruby2js/converter/send.rb
@@ -379,12 +379,12 @@ module Ruby2JS
         put "?."
         if method == :[]
           put '['
-          args.each {|arg| parse arg}
+          parse_all(*args, join: ', ')
           put ']'
         else
           put method.to_s
           put '(' if @ast.is_method?
-          args.each {|arg| parse arg}
+          parse_all(*args, join: ', ')
           put ')' if @ast.is_method?
         end
 

--- a/spec/es2020_spec.rb
+++ b/spec/es2020_spec.rb
@@ -54,6 +54,10 @@ describe "ES2020 support" do
       it "should support conditional indexing" do
         to_js('x=a&.[](b)').must_equal 'let x = a?.[b]'
       end
+
+      it "should handle method args with conditional chaining" do
+        to_js('x=a&.b&.c(d, e)').must_equal 'let x = a?.b?.c(d, e)'
+      end
     end
 
     it "should combine conditions when it can" do

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -966,6 +966,10 @@ describe Ruby2JS do
       it "should chain conditional attribute references" do
         to_js('x=a&.b&.c').must_equal 'var x = a && a.b && a.b.c'
       end
+
+      it "should handle method args with conditional chaining" do
+        to_js('x=a&.b(c, d)').must_equal 'var x = a && a.b(c, d)'
+      end
     end
 
     unless (RUBY_VERSION.split('.').map(&:to_i) <=> [3, 0, 0]) == -1


### PR DESCRIPTION
## Summary

Fixes a bug where function call arguments were missing comma delimiters when using the safe navigation operator (`&.`) with ES2020 optional chaining.

### Before

```ruby
x = a&.b&.c(d, e)
```

Generated invalid JavaScript:
```javascript
let x = a?.b?.c(de)
```

### After

Now correctly generates:
```javascript
let x = a?.b?.c(d, e)
```

## Technical Details

The fix changes `args.each {|arg| parse arg}` to `parse_all(*args, join: ', ')` in the `:csend` handler, matching how regular `:send` handles arguments.

## Test plan

- [x] Added test for method args with conditional chaining (transliteration_spec.rb)
- [x] Added test for ES2020 conditional chaining with args (es2020_spec.rb)
- [x] All existing tests pass

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)