### PR TITLE
Convert .times to for loop in functions filter

### DIFF
--- a/docs/src/_docs/filters/functions.md
+++ b/docs/src/_docs/filters/functions.md
@@ -62,6 +62,7 @@ If you set the `eslevel` option to `2015` or newer, the Functions filter enables
 * `.rstrip` {{ caret }} `.replace(/s+$/, "")`
 * `.scan` {{ caret }} `.match(//g)`
 * `.sum` {{ caret }} `.reduce(function(a, b) {a + b}, 0)`
+* `.times` {{ caret }} `for (let i = 0; i < n; i++)`
 * `.start_with?` {{ caret }} `.substring(0, arg.length) == arg` or `.startsWith(arg)` for ES2015+
 * `.upto(lim)` {{ caret }} `for (var i=num; i<=lim; i+=1)`
 * `.downto(lim)` {{ caret }} `for (var i=num; i>=lim; i-=1)`
@@ -104,6 +105,7 @@ If you set the `eslevel` option to `2015` or newer, the Functions filter enables
 * New classes subclassed off of `Exception` will become subclassed off
   of `Error` instead; and default constructors will be provided
 * `loop do...end` will be replaced with `while (true) {...}`
+* `n.times do...end` and `n.times { |i| ... }` will be replaced with `for` loops
 * `raise Exception.new(...)` will be replaced with `throw new Error(...)`
 * `block_given?` will check for the presence of optional argument `_implicitBlockYield` which is a function made accessible through the use of `yield` in a method body.
 * `alias_method` works both inside of a class definition as well as called directly on a class name (e.g. `MyClass.alias_method`)

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -568,6 +568,21 @@ describe Ruby2JS::Filter::Functions do
         must_equal 'while (true) {sleep(1); break}'
     end
 
+    it 'should handle times with block variable' do
+      to_js( '3.times { |i| console.log(i) }' ).
+        must_equal 'for (var i = 0; i < 3; i++) {console.log(i)}'
+    end
+
+    it 'should handle times without block variable' do
+      to_js( '3.times { console.log("hi") }' ).
+        must_equal 'for (var _ = 0; _ < 3; _++) {console.log("hi")}'
+    end
+
+    it 'should handle times with variable count' do
+      to_js( 'n.times { |i| console.log(i) }' ).
+        must_equal 'for (var i = 0; i < n; i++) {console.log(i)}'
+    end
+
     it 'should handles inspect' do
       to_js( 'a.inspect' ).must_equal 'JSON.stringify(a)'
     end


### PR DESCRIPTION
## Summary
- Adds support for Ruby's `.times` method in the functions filter
- Converts `.times` blocks to standard JavaScript `for` loops instead of leaving invalid `.times()` method calls
- Updates documentation to include `.times` in the list of transformations

## Examples

**With block variable:**
```ruby
3.times { |i| puts i }
```
```javascript
for (var i = 0; i < 3; i++) {console.log(i)}
```

**Without block variable:**
```ruby
3.times { puts "Welcome" }
```
```javascript
for (var _ = 0; _ < 3; _++) {console.log("Welcome")}
```

**With variable count:**
```ruby
n.times { |i| console.log(i) }
```
```javascript
for (var i = 0; i < n; i++) {console.log(i)}
```

## Test plan
- [x] Added 3 test cases for `.times` with/without block variable and variable count
- [x] All existing tests pass (1307 tests)
- [x] Updated functions filter documentation

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)