### PR TITLE
Fix Class.new blocks broken by return filter

### DIFF
--- a/lib/ruby2js/filter/return.rb
+++ b/lib/ruby2js/filter/return.rb
@@ -10,6 +10,14 @@ module Ruby2JS
       def on_block(node)
         node = super
         return node unless node.type == :block
+
+        # Don't wrap Class.new blocks - they contain method definitions, not return values
+        call = node.children.first
+        if call.type == :send and call.children[0]&.type == :const and
+           call.children[0].children == [nil, :Class] and call.children[1] == :new
+          return node
+        end
+
         children = node.children.dup
 
         children[-1] = s(:nil) if children.last == nil

--- a/spec/return_spec.rb
+++ b/spec/return_spec.rb
@@ -111,6 +111,27 @@ describe Ruby2JS::Filter::Return do
     end
   end
 
+  describe 'Class.new' do
+    def to_js_es2015(string)
+      _(Ruby2JS.convert(string, eslevel: 2015, filters: [Ruby2JS::Filter::Return]).to_s)
+    end
+
+    it "should not mangle Class.new blocks" do
+      to_js_es2015( 'kls = Class.new do; def foo; 42; end; end' ).
+        must_equal 'let kls = class {get foo() {return 42}}'
+    end
+
+    it "should not mangle Class.new with inheritance" do
+      to_js_es2015( 'kls = Class.new(Parent) do; def foo; 42; end; end' ).
+        must_equal 'let kls = class extends Parent {get foo() {return 42}}'
+    end
+
+    it "should not mangle Class.new with multiple methods" do
+      to_js_es2015( 'kls = Class.new do; def foo; 1; end; def bar; 2; end; end' ).
+        must_equal 'let kls = class {get foo() {return 1}; get bar() {return 2}}'
+    end
+  end
+
   describe Ruby2JS::Filter::DEFAULTS do
     it "should include Return" do
       _(Ruby2JS::Filter::DEFAULTS).must_include Ruby2JS::Filter::Return


### PR DESCRIPTION
## Summary
- Fixes `Class.new` blocks being mangled when the return filter is enabled
- Method definitions were incorrectly moved outside the class scope
- The fix skips `autoreturn` wrapping for `Class.new` blocks

## Problem
The return filter wraps block bodies with `:autoreturn`, which changed the AST structure. The converter checks `args.last.type == :def` to detect anonymous class definitions, but after the return filter, `args.last.type` becomes `:autoreturn` instead of `:def`, causing the class detection to fail.

## Example

**Before (broken):**
```javascript
let kls = class {};
function foo() { return 42 }  // method incorrectly outside class
```

**After (fixed):**
```javascript
let kls = class {
  get foo() { return 42 }  // method correctly inside class
}
```

## Test plan
- [x] Added 3 test cases for `Class.new` with return filter
- [x] Tests cover: simple method, inheritance, multiple methods
- [x] All existing tests pass (1307 tests)

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)