### PR TITLE
Fix export aliases in ESM exports

### DIFF
--- a/lib/ruby2js/converter/import.rb
+++ b/lib/ruby2js/converter/import.rb
@@ -127,12 +127,22 @@ module Ruby2JS
         )
         final_export = true
         put '{ '
-        node.children.each_with_index do |arg, index|
-          put ', ' unless index == 0
-          if arg.type == :hash && arg.children[0].children[0].children[0] == :default
-            put arg.children[0].children[1].children[1]
-            put ' as default'
+        first = true
+        node.children.each do |arg|
+          if arg.type == :hash
+            # Handle alias exports: four: alias1 => four as alias1
+            arg.children.each do |pair|
+              put ', ' unless first
+              first = false
+              key = pair.children[0].children[0]  # :sym node -> symbol
+              value = pair.children[1]            # the alias target
+              parse value
+              put ' as '
+              put key.to_s
+            end
           else
+            put ', ' unless first
+            first = false
             parse arg
           end
         end

--- a/spec/esm_spec.rb
+++ b/spec/esm_spec.rb
@@ -95,6 +95,9 @@ describe Ruby2JS::Filter::ESM do
 
       to_js("export [ A, default: B ]").
         must_include "export { A, B as default }"
+
+      to_js("export [one, two, three, four: alias1, five: alias2]").
+        must_include "export { one, two, three, alias1 as four, alias2 as five }"
     end
   end
 


### PR DESCRIPTION
## Summary
- Fixes export statements with aliases producing incorrect JavaScript output
- Previously `export [one, two, three, four: alias1, five: alias2]` would produce `export { one, two, three, {four: alias1, five: alias2} }` with the hash as an object literal
- Now correctly produces `export { one, two, three, alias1 as four, alias2 as five }`

Fixes #250

## Test plan
- [x] Added test case for export with multiple aliases
- [x] All existing ESM tests pass
- [x] Full test suite passes (1340 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)