### PR TITLE
Fix safe navigation with .call to produce optional chaining syntax

### DIFF
--- a/lib/ruby2js/converter/send.rb
+++ b/lib/ruby2js/converter/send.rb
@@ -452,6 +452,25 @@ module Ruby2JS
       end
     end
 
+    # ccall = conditional call (safe navigation function invocation)
+    # Ruby: foo&.call(x) -> JS: foo?.(x)
+    handle :ccall do |receiver, method, *args|
+      if es2020
+        parse receiver
+        put '?.('
+        parse_all(*args, join: ', ')
+        put ')'
+      else
+        # Fallback for pre-ES2020: receiver && receiver(args)
+        parse receiver
+        put ' && '
+        parse receiver
+        put '('
+        parse_all(*args, join: ', ')
+        put ')'
+      end
+    end
+
     handle :splat do |expr|
        put '...'
        parse expr

--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -65,6 +65,9 @@ module Ruby2JS
         result = on_send(node)
         if result&.type == :send and node.type == :csend
           result = result.updated(:csend)
+        elsif result&.type == :call and node.type == :csend
+          # Handle &.call -> ccall (conditional call) for optional chaining
+          result = result.updated(:ccall)
         end
         result
       end

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -643,6 +643,23 @@ describe Ruby2JS::Filter::Functions do
     it 'should handles cvars' do
       to_js( '@@f.call(1, 2, 3)' ).must_equal 'this.constructor._f(1, 2, 3)'
     end
+
+    it 'should handle safe navigation with ivar call' do
+      to_js_2020( '@f&.call(1, 2, 3)' ).must_equal 'this._f?.(1, 2, 3)'
+    end
+
+    it 'should handle safe navigation with cvar call' do
+      to_js_2020( '@@f&.call(1, 2, 3)' ).must_equal 'this.constructor._f?.(1, 2, 3)'
+    end
+
+    it 'should handle safe navigation call with include option' do
+      _(Ruby2JS.convert('foo&.call(x)', eslevel: 2020, include: [:call],
+        filters: [Ruby2JS::Filter::Functions]).to_s).must_equal 'foo?.(x)'
+    end
+
+    it 'should handle safe navigation call fallback for pre-ES2020' do
+      to_js( '@f&.call(1, 2, 3)' ).must_equal 'this._f && this._f(1, 2, 3)'
+    end
   end
 
   describe 'Exceptions' do


### PR DESCRIPTION
## Summary
- Fixes `&.call()` (safe navigation with `.call`) to output JavaScript's optional chaining function invocation syntax (`?.()`) instead of incorrectly keeping the `.call` method name
- Adds new `:ccall` (conditional call) node type for proper handling
- ES2020+: `@f&.call(x)` → `this._f?.(x)`
- Pre-ES2020 fallback: `@f&.call(x)` → `this._f && this._f(x)`

## Test plan
- [x] Added 4 new tests for safe navigation with `.call`
- [x] Full test suite passes (1460 runs, 0 failures)

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)