### PR TITLE
Fix method suffix stripping for optional chaining (csend)

### DIFF
--- a/lib/ruby2js/converter/send.rb
+++ b/lib/ruby2js/converter/send.rb
@@ -404,6 +404,9 @@ module Ruby2JS
         return
       end
 
+      # strip '!' and '?' decorations (same as send handler)
+      method = method.to_s[0..-2] if method =~ /\w[!?]$/
+
       # optional chaining
       parse receiver
       put "?."


### PR DESCRIPTION
## Summary
- Fix `!` and `?` suffix decorations not being stripped from method names when using optional chaining (`&.`)
- This caused `call!` to output `?.call!()` instead of `?.call()` with ES2020

## Example
```ruby
self.system.foo&.call!(type)
```

Before: `this.system.foo?.call!(type)` ❌
After: `this.system.foo?.call(type)` ✅

## Test plan
- [x] All existing tests pass (1484 runs, 2937 assertions)
- [x] Verified fix with the exact example from issue #262

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)