### PR TITLE
Fix typeof in arrow function expressions (issue #267)

### DIFF
--- a/lib/ruby2js/converter/return.rb
+++ b/lib/ruby2js/converter/return.rb
@@ -15,7 +15,7 @@ module Ruby2JS
     EXPRESSIONS = [ :array, :float, :hash, :int, :lvar, :nil, :send, :send!, :attr,
       :str, :sym, :dstr, :dsym, :cvar, :ivar, :zsuper, :super, :or, :and,
       :block, :const, :true, :false, :xnode, :taglit, :self,
-      :op_asgn, :and_asgn, :or_asgn, :taglit, :gvar, :csend, :call ]
+      :op_asgn, :and_asgn, :or_asgn, :taglit, :gvar, :csend, :call, :typeof ]
 
     handle :autoreturn do |*statements|
       return if statements.length == 1 && statements.first.nil?


### PR DESCRIPTION
## Summary
- Add `:typeof` to the `EXPRESSIONS` list in `converter/return.rb`
- Fixes arrow functions with `typeof` using statement blocks instead of expression syntax

**Before:**
```javascript
this.terms.map((term) => {typeof term == "number" ? term : term.total})
```

**After:**
```javascript
this.terms.map(term => typeof term == "number" ? term : term.total)
```

## Root Cause
The `functions` filter converts `typeof(x)` calls to `:typeof` AST nodes, but this node type wasn't in the `EXPRESSIONS` list. This caused the arrow function body to be treated as a statement (with braces) rather than an expression, resulting in `undefined` being returned.

## Test plan
- [x] All existing tests pass (1488 runs, 3036 assertions)
- [x] Verified fix with `--filter functions` and `--preset` options

Fixes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)