### PR TITLE
Recommend camelCase filter in Lit documentation

### DIFF
--- a/docs/src/_docs/filters/lit.md
+++ b/docs/src/_docs/filters/lit.md
@@ -10,10 +10,14 @@ The **Lit** filter makes it easier to build
 from Lit's documentation, rewritten in Ruby2JS (and you can inspect the compiled
 output to see nearly identical code.)
 
+{% rendercontent "docs/note" %}
+It is recommended to use the [camelCase](./camelCase) filter alongside the Lit filter. This allows you to write idiomatic Ruby (e.g., `custom_element`) which will be automatically converted to JavaScript conventions (e.g., `customElements.define`).
+{% endrendercontent %}
+
 <div data-controller="combo" data-options='{
   "eslevel": 2022,
   "autoexports": "default",
-  "filters": ["esm", "lit", "functions"]
+  "filters": ["esm", "lit", "functions", "camelCase"]
 }'></div>
 
 ```ruby


### PR DESCRIPTION
## Summary
- Add a note to the Lit filter documentation recommending the use of the camelCase filter
- Clarifies that `custom_element` is only converted to `customElements.define` when the camelCase filter is also applied
- Update the example filters to include `camelCase`

Closes #202

## Test plan
- [ ] Verify the documentation renders correctly on the site
- [ ] Confirm the note appears before the example code

🤖 Generated with [Claude Code](https://claude.com/claude-code)