### PR TITLE
Fix Lit example to use @name syntax in templates

### DIFF
--- a/docs/src/_docs/filters/lit.md
+++ b/docs/src/_docs/filters/lit.md
@@ -30,7 +30,7 @@ class SimpleGreeting < LitElement
 
   def render
     <<~HTML
-      <p>Hello, #{name}!</p>
+      <p>Hello, #{@name}!</p>
     HTML
   end
 end
@@ -50,7 +50,9 @@ When a class definition is encountered that derives from
  * References to instance variables will cause entries to be added to the
    `static properties` property if not already present, and simple type
    inferencing will be used to determine the type. (To bypass this for
-   truly internal state, use a prefixed ivar name like `@_x`.)
+   truly internal state, use a prefixed ivar name like `@_x`.) When
+   referencing properties in templates, use `@name` or `self.name` syntax
+   to ensure they are correctly prefixed with `this.` in the output.
 
  * `@styles` assignments, `self.styles` assignments and `self.styles` methods
    that return a string will have that string mapped to a


### PR DESCRIPTION
## Summary
- Change `#{name}` to `#{@name}` in the Lit filter example template
- Add documentation note explaining that `@name` or `self.name` syntax should be used when referencing properties in templates to ensure they get the `this.` prefix in JavaScript output

Closes #201

## Test plan
- [ ] Verify the documentation renders correctly
- [ ] Confirm the example compiles to valid JavaScript with `this.name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)