### PR TITLE
Remove deprecated --include-class flag from demo

### DIFF
--- a/demo/ruby2js.rb
+++ b/demo/ruby2js.rb
@@ -46,7 +46,6 @@ def parse_request(env=ENV)
 
   # extract options from the argument list
   options = {}
-  options[:include] = [:class] if ARGV.delete('--include-class')
   @live = ARGV.delete('--live')
   wunderbar_options = []
 


### PR DESCRIPTION
## Summary
- Remove the `--include-class` flag from `demo/ruby2js.rb`
- This flag is redundant since `--include=class` provides the same functionality

Closes #83

## Test plan
- [x] Demo still works with `--include=class` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)