### PR TITLE
Fix editor focus causing page scroll on iPadOS

### DIFF
--- a/demo/controllers/ruby_controller.js.rb
+++ b/demo/controllers/ruby_controller.js.rb
@@ -62,8 +62,8 @@ class RubyController < DemoController
     # populate editor with initial contents
     self.contents = contents if contents
 
-    # focus on the editor
-    @rubyEditor.focus()
+    # focus on the editor without scrolling page
+    @rubyEditor.focus(preventScroll: true)
 
     # do an initial conversion as soon as Ruby2JS comes online
     await ruby2js_ready


### PR DESCRIPTION
## Summary
- Use `preventScroll: true` option when focusing the editor
- Prevents the page from automatically scrolling to the editor on page load
- Fixes issue where top navigation and content were obscured on iPadOS with an external keyboard attached

Closes #139

## Test plan
- [ ] Verify editor still receives focus on page load (keyboard input works)
- [ ] Verify page does not scroll when editor is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)