### PR TITLE
Fix super in class methods to use super.method instead of Parent.method

### DIFF
--- a/lib/ruby2js/converter/super.rb
+++ b/lib/ruby2js/converter/super.rb
@@ -26,8 +26,7 @@ module Ruby2JS
       add_args = true
 
       if @class_method
-        parse @class_parent
-        put '.'
+        put 'super.'
         put method.children[0]
         add_args = method.is_method?
       elsif method.children[0] == :constructor

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -697,6 +697,15 @@ describe Ruby2JS do
         must_equal 'class A {}; class B extends A {foo(x) {super.foo(3)}}'
     end
 
+    it "should handle super in class methods" do
+      to_js('class A; end; class B < A; def self.foo(x); super; end; end').
+        must_equal 'class A {}; class B extends A {static foo(x) {super.foo(x)}}'
+      to_js('class A; end; class B < A; def self.foo(x); super(3); end; end').
+        must_equal 'class A {}; class B extends A {static foo(x) {super.foo(3)}}'
+      to_js('class A; end; class B < A; def self.bar; super; end; end').
+        must_equal 'class A {}; class B extends A {static get bar() {return super.bar}}'
+    end
+
     it "should parse class with class variables" do
       to_js('class Person; @@count=0; end').
         must_equal 'class Person {}; Person._count = 0'


### PR DESCRIPTION
## Summary
- Fixes #274
- Changes `super` in static methods (`def self.method`) to output `super.method()` instead of `ParentClass.method()`
- Adds tests for super in class methods

## Details

When calling `super` inside a class method:

```ruby
class FormulaField < StringField
  def self._defaults
    return mergeObject(super, deterministic: false)
  end
end
```

**Before:**
```javascript
return mergeObject(StringField._defaults, {deterministic: false})
```

**After:**
```javascript
return mergeObject(super._defaults, {deterministic: false})
```

Using `super` is the correct JavaScript idiom because:
- It properly follows the prototype chain if `StringField` also extends another class
- It's more maintainable - renaming the parent class doesn't require updating super calls
- It matches how instance method super calls already worked

## Test plan
- [x] Added new test case for `super` in class methods
- [x] All existing tests pass (1527 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)