### PR TITLE
Fix local variable assignment confused with getter methods

### DIFF
--- a/lib/ruby2js/converter/class2.rb
+++ b/lib/ruby2js/converter/class2.rb
@@ -85,7 +85,8 @@ module Ruby2JS
                 end
               end
             elsif prop.to_s.end_with? '='
-              base_node = s(:autobind, s(:self))
+              # Use :setter marker so vasgn.rb can distinguish setters from regular methods
+              base_node = s(:setter, s(:self))
               # Wrap private setters so send.rb can apply the prefix
               if method_visibility == :private
                 private_methods << prop # Pragma: set

--- a/lib/ruby2js/converter/opasgn.rb
+++ b/lib/ruby2js/converter/opasgn.rb
@@ -15,7 +15,10 @@ module Ruby2JS
       if var.type == :lvar
         name = var.children.first
         receiver = @rbstack.map {|rb| rb[name]}.compact.last
-        if receiver
+        # Only convert to property assignment if it's a setter (not a regular getter/method)
+        is_setter = receiver&.type == :setter ||
+          (receiver&.type == :private_method && receiver.children[1]&.type == :setter)
+        if is_setter
           var = s(:attr, nil, name)
         end
       end

--- a/lib/ruby2js/converter/send.rb
+++ b/lib/ruby2js/converter/send.rb
@@ -160,6 +160,10 @@ module Ruby2JS
         if receiver.type == :autobind
           autobind = receiver = receiver.children.first
           autobind = nil unless @autobind
+        elsif receiver.type == :setter
+          # Setter markers are only used by vasgn.rb/opasgn.rb for assignment;
+          # for method calls, just extract the actual receiver
+          receiver = receiver.children.first
         end
 
         # Handle private methods - extract prefix and inner receiver
@@ -169,6 +173,8 @@ module Ruby2JS
           if receiver.type == :autobind
             autobind = receiver = receiver.children.first
             autobind = nil unless @autobind
+          elsif receiver.type == :setter
+            receiver = receiver.children.first
           end
         end
 

--- a/lib/ruby2js/filter/stimulus.rb
+++ b/lib/ruby2js/filter/stimulus.rb
@@ -126,29 +126,32 @@ module Ruby2JS
           end
         end
 
-        props = [:element, :application]
+        # Read-only properties use s(:self)
+        readonly_props = [:element, :application]
 
-        props += @stim_targets.map do |name|
+        readonly_props += @stim_targets.map do |name|
           name = name.children.first
           ["#{name}Target", "#{name}Targets", "has#{name[0].upcase}#{name[1..-1]}Target"]
         end
 
-        props += @stim_values.map do |name|
-          name = name.children.first
-          ["#{name}Value", "has#{name[0].upcase}#{name[1..-1]}Value"]
-        end
-
-        props += @stim_classes.map do |name|
+        readonly_props += @stim_classes.map do |name|
           name = name.children.first
           ["#{name}Class", "has#{name[0].upcase}#{name[1..-1]}Class"]
         end
 
-        props += @stim_outlets.map do |name|
+        readonly_props += @stim_outlets.map do |name|
           name = name.children.first
           ["#{name}Outlet", "#{name}Outlets", "has#{name[0].upcase}#{name[1..-1]}Outlet"]
         end
 
-        props = props.flatten.map {|prop| [prop.to_sym, s(:self)]}.to_h
+        # Value properties are read-write, use s(:setter, s(:self)) to support assignment
+        value_props = @stim_values.map do |name|
+          name = name.children.first
+          ["#{name}Value", "has#{name[0].upcase}#{name[1..-1]}Value"]
+        end
+
+        props = readonly_props.flatten.map {|prop| [prop.to_sym, s(:self)]}.to_h
+        props.merge!(value_props.flatten.map {|prop| [prop.to_sym, s(:setter, s(:self))]}.to_h)
 
         props[:initialize] = s(:autobind, s(:self))
 

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -831,6 +831,13 @@ describe Ruby2JS do
         must_equal 'class C {set a(x) {this._a = x}; b() {this.a++}}'
     end
 
+    it "should not confuse getter methods with setter assignments (issue #277)" do
+      # When a getter method exists, local variable assignment should create
+      # a local variable, not call a setter
+      to_js('class C; def var2; "x"; end; def test; var2 = "abc"; puts var2; end; end').
+        must_equal 'class C {get var2() {return "x"}; get test() {let var2 = "abc"; return puts(var2)}}'
+    end
+
     it "should prefix bind references to methods as properties" do
       to_js('class C; def m1(); end; def m2; m1; end; end').
         must_equal 'class C {m1() {}; get m2() {return this.m1.bind(this)}}'


### PR DESCRIPTION
## Summary

Fixes #277

When a class has a getter method (e.g., `def var2`), assigning to a local variable with the same name (`var2 = "abc"`) was incorrectly being converted to a property assignment (`this.var2 = "abc"`) instead of creating a new local variable (`let var2 = "abc"`).

**Before (incorrect):**
```ruby
class Foo
  def var2; "123456789"; end
  def test
    var2 = "abc"  # Should be local variable
    puts var2
  end
end
```
```javascript
// Was incorrectly generating:
this.var2 = "abc"  // Wrong! Assigns to property
```

**After (correct):**
```javascript
let var2 = "abc"  // Correct! Creates local variable
```

### Root Cause

Both getter methods and setter methods were being registered in `@rbstack`, and `vasgn.rb` treated any match as a setter call. In Ruby, `var = x` always creates a local variable; only `self.var = x` calls a setter.

### Fix

Use a distinct `:setter` marker node for setter methods so that `vasgn.rb` and `opasgn.rb` can distinguish them from regular methods:

- `class2.rb`: Use `s(:setter, s(:self))` for setter methods
- `vasgn.rb`: Only convert to `this.x =` if rbstack entry is `:setter`
- `opasgn.rb`: Same check for operator assignments like `x += 1`
- `send.rb`: Handle `:setter` marker extraction (like `:autobind`)
- `stimulus.rb`: Use `:setter` marker for Stimulus value properties

## Test plan

- [x] Added test case for issue #277 in `transliteration_spec.rb`
- [x] All Ruby tests pass (1423 runs, 2862 assertions, 0 failures)
- [x] All selfhost CI tests pass (transliteration: 251 passed, serializer: 26 passed, namespace: 9 passed)
- [x] Verified setter behavior still works (`def a=` with `a = 1` → `this.a = 1`)
- [x] Verified Stimulus value properties still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)