### PR TITLE
Load sql.js dynamically only when sqljs adapter is used

### DIFF
--- a/demo/ruby2js-on-rails/README.md
+++ b/demo/ruby2js-on-rails/README.md
@@ -37,6 +37,47 @@ The same Ruby source code can be transpiled to run on different platforms:
 
 The target is determined by the database adapter in `config/database.yml` or the `DATABASE` environment variable. The runtime can be set via the `RUNTIME` environment variable (node, bun, or deno).
 
+## Selecting a Database Adapter
+
+### Browser Adapters
+
+For browser builds, two database adapters are available:
+
+| Adapter | Size | Persistence | Use Case |
+|---------|------|-------------|----------|
+| **dexie** (default) | ~50KB | Persistent (IndexedDB) | Most browser apps |
+| **sqljs** | ~2.7MB | In-memory only | Full SQL support, testing |
+
+**Using Dexie (default):**
+```bash
+npm run dev
+# Or explicitly:
+DATABASE=dexie npm run dev
+```
+
+**Using sql.js:**
+```bash
+DATABASE=sqljs npm run dev
+```
+
+Or edit `config/database.yml`:
+```yaml
+development:
+  adapter: sqljs
+  database: ruby2js_rails_dev
+```
+
+The sql.js adapter loads the ~2.7MB WASM file dynamically when the app starts. This is loaded on-demand, so apps using Dexie don't pay this cost.
+
+### Server Adapters
+
+For server builds (Node.js, Bun, Deno):
+
+```bash
+DATABASE=better_sqlite3 npm run dev:node   # SQLite (default for server)
+DATABASE=pg npm run dev:node               # PostgreSQL
+```
+
 ## Available Commands
 
 | Command | Description |

--- a/demo/ruby2js-on-rails/index.html
+++ b/demo/ruby2js-on-rails/index.html
@@ -25,7 +25,6 @@
     <main id="content"></main>
   </div>
 
-  <script src="/node_modules/sql.js/dist/sql-wasm.js"></script>
   <script type="module">
     import { Application, routes } from '/dist/config/routes.js';
     window.routes = routes;

--- a/docs/src/demo/ruby2js-on-rails/index.html
+++ b/docs/src/demo/ruby2js-on-rails/index.html
@@ -55,11 +55,7 @@
     <main id="content"></main>
   </div>
 
-  <script src="node_modules/sql.js/dist/sql-wasm.js"></script>
   <script type="module">
-    // Configure sql.js WASM location for hosted environment
-    window.SQL_WASM_PATH = '/demo/ruby2js-on-rails/node_modules/sql.js/dist/';
-
     import { Application, routes } from './dist/config/routes.js';
     window.routes = routes;
     Application.start();


### PR DESCRIPTION
## Summary

- Remove static `sql-wasm.js` script tag from index.html files
- Modify sqljs adapter to dynamically load sql-wasm.js on demand
- Auto-detect correct path using `<base href>` for hosted environments
- Add documentation for selecting database adapters

## Problem

The demo always loaded `sql-wasm.js` via a static script tag, even when using the default `dexie` adapter. This caused 404 errors when `sql.js` wasn't installed in `node_modules`.

## Solution

The sqljs adapter now loads the WASM file dynamically when `initDatabase()` is called:

```javascript
// Load sql-wasm.js only when needed
await loadSqlJs(`${sqlJsPath}/sql-wasm.js`);
```

Apps using dexie (default) no longer require sql.js to be present.

## How to Select sql.js

To use sql.js instead of the default dexie adapter:

**Option 1: Environment variable**
```bash
DATABASE=sqljs npm run dev
```

**Option 2: Edit config/database.yml**
```yaml
development:
  adapter: sqljs
  database: ruby2js_rails_dev
```

## Test plan

- [ ] Run demo with dexie (default): `npm run dev` - should work without sql.js errors
- [ ] Run demo with sqljs: `DATABASE=sqljs npm run dev` - should load sql.js dynamically
- [ ] Verify hosted demo works at ruby2js.com after deployment

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)