### PR TITLE
Fix navigation menu links in ruby2js-on-rails demo

### DIFF
--- a/demo/ruby2js-on-rails/index.html
+++ b/demo/ruby2js-on-rails/index.html
@@ -17,9 +17,9 @@
   <div id="loading">Loading Ruby2JS-on-Rails...<br><small>Powered by transpiled Ruby code</small></div>
   <div id="app">
     <nav>
-      <a onclick="navigate('/')">Home</a>
-      <a onclick="navigate('/articles')">Articles</a>
-      <a onclick="navigate('/articles/new')">New Article</a>
+      <a href="/" onclick="return navigate(event, '/')">Home</a>
+      <a href="/articles" onclick="return navigate(event, '/articles')">Articles</a>
+      <a href="/articles/new" onclick="return navigate(event, '/articles/new')">New Article</a>
       <span class="transpiled-badge">Transpiled Ruby &rarr; JS</span>
     </nav>
     <main id="content"></main>


### PR DESCRIPTION
## Summary
- Fixed navigation links that were calling `navigate(path)` instead of `navigate(event, path)`
- Added `href` attributes as fallback for non-JavaScript browsers
- Added `return` to prevent default navigation when JS is enabled

## Root Cause
The `navigate()` function in `rails.js` expects two arguments `(event, path)`, but the HTML was calling it with only one argument `(path)`. This caused `Router.dispatch()` to receive `undefined` instead of the path.

## Test plan
- [ ] Open the ruby2js-on-rails demo
- [ ] Click Home, Articles, and New Article links
- [ ] Verify navigation works correctly without page reload

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)