### PR TITLE
Fix race condition when Ruby2JS is already loaded

### DIFF
--- a/demo/controllers/ruby_controller.js.rb
+++ b/demo/controllers/ruby_controller.js.rb
@@ -74,20 +74,21 @@ class RubyController < DemoController
 
   # Load the Opal Ruby2JS bundle dynamically
   async def load_opal()
-    return if defined? Ruby2JS
+    unless defined? Ruby2JS
+      # Load the Opal bundle via script tag (it's not an ES module)
+      await Promise.new do |resolve, reject|
+        script = document.createElement('script')
+        script.src = "#{window.location.origin}/demo/ruby2js.js"
+        script.async = true
+        script.addEventListener(:load, resolve)
+        script.addEventListener(:error, reject)
+        document.head.appendChild(script)
+      end
 
-    # Load the Opal bundle via script tag (it's not an ES module)
-    await Promise.new do |resolve, reject|
-      script = document.createElement('script')
-      script.src = "#{window.location.origin}/demo/ruby2js.js"
-      script.async = true
-      script.addEventListener(:load, resolve)
-      script.addEventListener(:error, reject)
-      document.head.appendChild(script)
+      # Wait for Ruby2JS to be ready
+      await ruby2js_ready
     end
 
-    # Wait for Ruby2JS to be ready
-    await ruby2js_ready
     @opal_ready = true
   end
 


### PR DESCRIPTION
## Summary

- Fixes a race condition where JavaScript demos would show "content" instead of converted code when navigating between pages via Turbo

## Problem

When navigating via Turbo from a page that had already loaded `ruby2js.js`, the `load_opal()` method would return early because `Ruby2JS` was already defined, but it would skip setting `@opal_ready = true`. This caused `convert()` to always return early, leaving the JavaScript editor displaying the default "content" placeholder.

## Solution

Restructured `load_opal()` so that `@opal_ready = true` is always set, regardless of whether the script needed to be loaded:

```ruby
async def load_opal()
  unless defined? Ruby2JS
    # ... load script ...
  end
  @opal_ready = true  # Always set
end
```

## Test plan

- [ ] Visit a User's Guide page with live demos (e.g., /docs/users-guide/patterns)
- [ ] Verify JavaScript output is displayed correctly
- [ ] Navigate to another page via Turbo
- [ ] Navigate back and verify demos still work (no "content" placeholder)

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)