### PR TITLE
Fix JSX examples to use Ruby lambda syntax instead of JS arrow functions

### DIFF
--- a/docs/src/_docs/filters/react.md
+++ b/docs/src/_docs/filters/react.md
@@ -30,7 +30,7 @@ class Counter < React
     %x{
       <div>
         <p>Count: {count}</p>
-        <button onClick={() => setCount(count + 1)}>Increment</button>
+        <button onClick={-> { setCount(count + 1) }}>Increment</button>
       </div>
     }
   end

--- a/docs/src/_docs/users-guide/components.md
+++ b/docs/src/_docs/users-guide/components.md
@@ -60,7 +60,7 @@ class Counter < React
     %x{
       <div>
         <p>Count: {count}</p>
-        <button onClick={() => setCount(count + 1)}>+</button>
+        <button onClick={-> { setCount(count + 1) }}>+</button>
       </div>
     }
   end


### PR DESCRIPTION
## Summary

- Fixed documentation examples that were using JavaScript arrow function syntax inside JSX `{...}` blocks
- Changed `onClick={() => setCount(count + 1)}` to `onClick={-> { setCount(count + 1) }}`

The `{...}` syntax inside Ruby2JS JSX should contain Ruby expressions, not JavaScript. The examples were using JavaScript arrow function syntax `() => ...` which causes a parsing error:

```
:6:20: error: unexpected token tASSOC
:6: button(onClick: () => setCount(count + 1)) do
```

Ruby lambdas `-> { ... }` are correctly converted to JavaScript arrow functions `() => ...`.

## Test plan

- [x] Verified the corrected examples parse without errors
- [x] Verified the generated JavaScript is correct

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)